### PR TITLE
Validate function options during the execution.

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -27,6 +27,7 @@ import com.jayway.jsonpath.PathNotFoundException;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.Constants;
+import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.ruleset.Format;
 import org.wso2.rule.validator.ruleset.Rule;
@@ -80,7 +81,7 @@ public class Document {
         }
     }
 
-    public ArrayList<FunctionResult> lint(Ruleset ruleset) {
+    public ArrayList<FunctionResult> lint(Ruleset ruleset) throws InvalidRulesetException {
         // TODO: Add parsing errors to the result set
 
         // TODO: Filter enabled and relevant rules
@@ -124,7 +125,7 @@ public class Document {
          */
     }
 
-    private ArrayList<FunctionResult> lintNode(String path, Rule rule) {
+    private ArrayList<FunctionResult> lintNode(String path, Rule rule) throws InvalidRulesetException {
         ArrayList<FunctionResult> results = new ArrayList<>();
         Object node;
         try {

--- a/component/src/main/java/org/wso2/rule/validator/functions/LintFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/LintFunction.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.rule.validator.functions;
 
+import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.LintTarget;
 
 import java.util.List;
@@ -30,7 +31,15 @@ public abstract class LintFunction {
 
     public Map<String, Object> options;
 
-    public abstract boolean execute(LintTarget target);
+    public boolean execute(LintTarget target) throws InvalidRulesetException {
+        List<String> errors = validateFunctionOptions();
+        if (!errors.isEmpty()) {
+            throw new InvalidRulesetException("Function options are invalid: " + errors);
+        }
+        return executeFunction(target);
+    }
+
+    protected abstract boolean executeFunction(LintTarget target);
 
     public LintFunction(Map<String, Object> options) {
         this.options = options;

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
@@ -59,7 +59,7 @@ public class AlphabeticalFunction extends LintFunction {
 
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         return target.value.toString().matches(Constants.RULESET_ALPHABETICAL_REGEX);
     }
 

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
@@ -90,7 +90,7 @@ public class CasingFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         String targetString = (String) target.value;
         boolean allowLeading = Constants.RULESET_CASING_SEPARATOR_ALLOW_LEADING_DEFAULT;
         String separatorChar = "";

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
@@ -46,7 +46,7 @@ public class DefinedFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         return target.value != null;
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
@@ -53,7 +53,7 @@ public class EnumerationFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         String[] values = (String[]) options.get(Constants.RULESET_ENUMERATION_VALUES);
         for (String value : values) {
             if (target.value.equals(value)) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
@@ -46,7 +46,7 @@ public class FalsyFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         if (target.value instanceof String) {
             return ((String) target.value).isEmpty();
         } else if (target.value instanceof List) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
@@ -63,7 +63,7 @@ public class LengthFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         int length;
 
         if (target.value instanceof String) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
@@ -89,7 +89,7 @@ public class PatternFunction extends LintFunction {
         }
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         Object match = options.get(Constants.RULESET_PATTERN_MATCH);
         Object notMatch = options.get(Constants.RULESET_PATTERN_NOT_MATCH);
 

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
@@ -92,7 +92,7 @@ public class SchemaFunction extends LintFunction {
         }
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
 
         String targetString = new Gson().toJson(target.value);
         JSONObject targetObject = new JSONObject(targetString);

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
@@ -46,7 +46,7 @@ public class TruthyFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         if (target.value instanceof String) {
             return !((String) target.value).isEmpty();
         } else if (target.value instanceof List) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
@@ -46,7 +46,7 @@ public class UndefinedFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         return target.value == null;
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
@@ -66,7 +66,7 @@ public class XorFunction extends LintFunction {
         return errors;
     }
 
-    public boolean execute(LintTarget target) {
+    public boolean executeFunction(LintTarget target) {
         ArrayList<String> properties = (ArrayList<String>) options.get(Constants.RULESET_XOR_PROPERTIES);
         int count = 0;
         for (String property : properties) {


### PR DESCRIPTION
## Purpose
Function options are validated before the function is executed to make the behaviour similar to Spectral.

- The `execute` method has been ranamed to `executeFunction` and made `protected`, so it can be extended by core functions but cannot be called from outside the package.
- The execute method is changed so it can (should) be called be called from each core function, so options are validated before the execution.