### PR TITLE
Changed validation response structures.

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
+++ b/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
@@ -25,5 +25,22 @@ public enum DiagnosticSeverity {
     WARN,
     INFO,
     HINT,
-    OFF
+    OFF;
+
+    public static String getSeverityString(DiagnosticSeverity severity) {
+        switch (severity) {
+            case ERROR:
+                return "error";
+            case WARN:
+                return "warn";
+            case INFO:
+                return "info";
+            case HINT:
+                return "hint";
+            case OFF:
+                return "off";
+            default:
+                return "off";
+        }
+    }
 }

--- a/component/src/main/java/org/wso2/rule/validator/InvalidContentTypeException.java
+++ b/component/src/main/java/org/wso2/rule/validator/InvalidContentTypeException.java
@@ -1,0 +1,10 @@
+package org.wso2.rule.validator;
+
+/**
+ * Exception to handle invalid content type. Content type must be either JSON or YAML.
+ */
+public class InvalidContentTypeException extends Exception {
+    public InvalidContentTypeException(String message) {
+        super("Invalid content type. Rulesets and documents must be either valid JSON or YAML." + "\n" + message);
+    }
+}

--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -160,7 +160,7 @@ public class Document {
                 }
                 boolean result = then.lintFunction.execute(target);
                 String targetPath = target.getPathString();
-                results.add(new FunctionResult(result, path + targetPath, rule.message, rule));
+                results.add(new FunctionResult(result, path + targetPath, rule));
             }
         }
         return results;

--- a/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
@@ -25,21 +25,19 @@ import org.wso2.rule.validator.ruleset.Rule;
 public class FunctionResult {
     public final boolean passed;
     public final String path;
-    public final String message;
-    public final String ruleName;
+    public final Rule rule;
 
-    public FunctionResult(boolean passed, String path, String message, Rule rule) {
+    public FunctionResult(boolean passed, String path, Rule rule) {
         this.passed = passed;
         this.path = path;
-        this.message = message;
-        this.ruleName = rule.name;
+        this.rule = rule;
     }
 
     public String toString() {
-        return "Rule: " + ruleName + " {\n" +
+        return "Rule: " + this.rule.name + " {\n" +
                 "\tpassed=" + passed +
                 "\n\tpath='" + path + '\'' +
-                "\n\tmessage='" + message + '\'' +
+                "\n\tmessage='" + this.rule.message + '\'' +
                 "\n}";
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
@@ -33,7 +33,7 @@ public class Rule {
     public String name;
     private String description;
     public String message;
-    private DiagnosticSeverity severity;
+    public DiagnosticSeverity severity;
     private boolean resolved;
     public List<RuleThen> then;
     public List<String> given;

--- a/component/src/main/java/org/wso2/rule/validator/validator/DocumentValidationResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/DocumentValidationResult.java
@@ -1,0 +1,20 @@
+package org.wso2.rule.validator.validator;
+
+import org.wso2.rule.validator.DiagnosticSeverity;
+
+/**
+ * Class to represent the result of a document validation that is sent to the user
+ */
+public class DocumentValidationResult {
+    public final String path;
+    public final String message;
+    public final String ruleName;
+    public final String severity;
+
+    public DocumentValidationResult(String path, String message, String ruleName, DiagnosticSeverity severity) {
+        this.path = path;
+        this.message = message;
+        this.ruleName = ruleName;
+        this.severity = DiagnosticSeverity.getSeverityString(severity);
+    }
+}

--- a/component/src/main/java/org/wso2/rule/validator/validator/RulesetValidationError.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/RulesetValidationError.java
@@ -31,6 +31,9 @@ public class RulesetValidationError {
     }
 
     public String toString() {
-        return "Rule: " + ruleName + ", Message: " + message;
+        if (ruleName.isEmpty()) {
+            return message;
+        }
+        return "Rule name: " + ruleName + ", Message: " + message;
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidationResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidationResult.java
@@ -1,0 +1,14 @@
+package org.wso2.rule.validator.validator.ruleset;
+
+/**
+ * Represents the result of a ruleset validation that is sent back to the user
+ */
+public class RulesetValidationResult {
+    public final boolean passed;
+    public final String message;
+
+    public RulesetValidationResult(boolean passed, String message) {
+        this.passed = passed;
+        this.message = message;
+    }
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -40,4 +40,12 @@
         <Class name="org.wso2.rule.validator.ruleset.RulesetAliasTarget"/>
         <Bug pattern="URF_UNREAD_FIELD"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.rule.validator.validator.DocumentValidationResult"/>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.rule.validator.validator.ruleset.RulesetValidationResult"/>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Fixes

1. The response of the document validation now looks like the following.
```
{
    "path": "$['paths']['/workflows']['get']['summary']",
    "message": "",
    "ruleName": "api-resource-paths-kebab-case",
    "severity": "error"
}
```

2. The response of the ruleset validation now looks like the following.
```
{
  "passed": false,
  "message": "Rule name: api-resource-paths-kebab-case, Message: Rule does not contain a 'given' field.\nRule name: api-resource-paths-kebab-case, Message: Invalid severity: errors\n"
}
```

3. A new logic is introduced to identify file type as either YAML or JSON, and handles invalid file types.