### PR TITLE
Fix using implementation instead of interface for containers.

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -48,7 +48,7 @@ public class Document {
 
     private String documentString;
     private Object document;
-    ArrayList<Format> formats;
+    List<Format> formats;
 
     public Document(String documentString) {
         LoadSettings settings = LoadSettings.builder().build();
@@ -86,9 +86,9 @@ public class Document {
         }
     }
 
-    public ArrayList<FunctionResult> lint(Ruleset ruleset) throws InvalidRulesetException {
+    public List<FunctionResult> lint(Ruleset ruleset) throws InvalidRulesetException {
 
-        ArrayList<FunctionResult> results = new ArrayList<>();
+        List<FunctionResult> results = new ArrayList<>();
 
         for (Rule rule : ruleset.rules.values()) {
             if (!matchFormat(ruleset, rule)) {
@@ -106,7 +106,6 @@ public class Document {
                     // log("Json Path not found: " + given);
                 } catch (InvalidPathException e) {
                     // log("Unsupported Json Path: " + given);
-                    // TODO: Implement json path plus features
                 }
             }
         }
@@ -125,7 +124,6 @@ public class Document {
     }
 
     private void resolveReferences() {
-        // TODO: Resolve references
         /**
          * A document Inventory maintains a graph (non-circular) pointing to other documents via refs. When a ref is in
          * a document, it adds a Node in the graph pointing to the document, and if there are refs within that ref, that
@@ -136,8 +134,8 @@ public class Document {
          */
     }
 
-    private ArrayList<FunctionResult> lintNode(String path, Rule rule) throws InvalidRulesetException {
-        ArrayList<FunctionResult> results = new ArrayList<>();
+    private List<FunctionResult> lintNode(String path, Rule rule) throws InvalidRulesetException {
+        List<FunctionResult> results = new ArrayList<>();
         Object node;
         try {
             node = JsonPath.read(this.document, path);
@@ -145,7 +143,7 @@ public class Document {
             return results;
         }
         for (RuleThen then : rule.then) {
-            ArrayList<LintTarget> lintTargets = getLintTargets(node, then);
+            List<LintTarget> lintTargets = getLintTargets(node, then);
 
             for (LintTarget target : lintTargets) {
                 if (target.value == null) {
@@ -159,8 +157,8 @@ public class Document {
         return results;
     }
 
-    private ArrayList<LintTarget> getLintTargets(Object node, RuleThen then) {
-        ArrayList<LintTarget> lintTargets = new ArrayList<>();
+    private List<LintTarget> getLintTargets(Object node, RuleThen then) {
+        List<LintTarget> lintTargets = new ArrayList<>();
 
         if ((node instanceof List || node instanceof Map) && (then.field != null && !then.field.isEmpty())) {
             if (then.field.equals(Constants.RULESET_FIELD_KEY)) {
@@ -188,7 +186,7 @@ public class Document {
                 }
 
                 for (String path : paths) {
-                    ArrayList<String> splitPath = splitJsonPath(path);
+                    List<String> splitPath = splitJsonPath(path);
                     Object value;
                     try {
                         value = JsonPath.read(node, path);
@@ -198,7 +196,7 @@ public class Document {
                     }
                 }
             } else {
-                ArrayList<String> path = toPath(then.field);
+                List<String> path = toPath(then.field);
                 Object value;
                 try {
                     value = JsonPath.read(node, then.field);
@@ -214,8 +212,8 @@ public class Document {
         return lintTargets;
     }
 
-    public static ArrayList<String> splitJsonPath(String jsonPath) {
-        ArrayList<String> parts = new ArrayList<>();
+    public static List<String> splitJsonPath(String jsonPath) {
+        List<String> parts = new ArrayList<>();
         StringBuilder currentPart = new StringBuilder();
         boolean insideBrackets = false;
 
@@ -235,8 +233,8 @@ public class Document {
         return parts;
     }
 
-    public static ArrayList<String> toPath(String path) {
-        ArrayList<String> segments = new ArrayList<>();
+    public static List<String> toPath(String path) {
+        List<String> segments = new ArrayList<>();
 
         // Regex to match either dot-separated keys or bracket notation
         Pattern pattern = Pattern.compile(Constants.JSON_PATH_GROUPING_REGEX);

--- a/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
@@ -17,16 +17,16 @@
  */
 package org.wso2.rule.validator.document;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class represents a lint target in a document.
  */
 public class LintTarget {
-    public ArrayList<String> jsonPath;
+    public List<String> jsonPath;
     public final Object value;
 
-    public LintTarget(ArrayList<String> jsonPath, Object value) {
+    public LintTarget(List<String> jsonPath, Object value) {
         this.jsonPath = jsonPath;
         this.value = value;
     }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
@@ -39,7 +39,7 @@ public class AlphabeticalFunction extends LintFunction {
     @Override
     public List<String> validateFunctionOptions() {
 
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             return errors;
@@ -99,7 +99,7 @@ public class AlphabeticalFunction extends LintFunction {
     }
 
     private boolean isAlphabetical(List<Object> objectList, String key) {
-        ArrayList<Object> list = new ArrayList<>();
+        List<Object> list = new ArrayList<>();
         for (Object obj : objectList) {
             Map<String, Object> map = (Map) obj;
             list.add(map.get(key));

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
@@ -49,7 +49,7 @@ public class CasingFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("At least the casing type should be specified in functionOptions in the 'casing' function.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
@@ -37,7 +37,7 @@ public class DefinedFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options != null && !options.isEmpty()) {
             errors.add("Defined function does not accept any options.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
@@ -38,7 +38,7 @@ public class EnumerationFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("Enumeration function requires the set of values.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
@@ -37,7 +37,7 @@ public class FalsyFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options != null && !options.isEmpty()) {
             errors.add("Falsy function does not accept any options.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
@@ -38,7 +38,7 @@ public class LengthFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("Length function requires at least a min or a max value.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
@@ -52,7 +52,7 @@ public class PatternFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("Pattern function requires a regex pattern");
@@ -113,7 +113,6 @@ public class PatternFunction extends LintFunction {
     }
 
     private PatternAndFlags extractPatternAndFlags(String regex) {
-        // TODO: Process
         String pattern = regex;
         String flags = "";
         if (regex.startsWith("/") && regex.lastIndexOf("/") > 0) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
@@ -44,7 +44,7 @@ public class SchemaFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("Schema function should at least contain the schema option.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
@@ -37,7 +37,7 @@ public class TruthyFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options != null && !options.isEmpty()) {
             errors.add("Truthy function does not accept any options.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
@@ -37,7 +37,7 @@ public class UndefinedFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options != null && !options.isEmpty()) {
             errors.add("Undefined function does not take any options.");

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
@@ -38,7 +38,7 @@ public class XorFunction extends LintFunction {
 
     @Override
     public List<String> validateFunctionOptions() {
-        ArrayList<String> errors = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
 
         if (options == null) {
             errors.add("Xor function requires the list of properties.");
@@ -67,7 +67,7 @@ public class XorFunction extends LintFunction {
     }
 
     public boolean executeFunction(LintTarget target) {
-        ArrayList<String> properties = (ArrayList<String>) options.get(Constants.RULESET_XOR_PROPERTIES);
+        List<String> properties = (List<String>) options.get(Constants.RULESET_XOR_PROPERTIES);
         int count = 0;
         for (String property : properties) {
             if (target.value instanceof Map) {

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Format.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Format.java
@@ -99,8 +99,8 @@ public enum Format {
         }
     }
 
-    public static ArrayList<Format> getFormatListFromObject(List<String> formatStrings) {
-        ArrayList<Format> formats = new ArrayList<>();
+    public static List<Format> getFormatListFromObject(List<String> formatStrings) {
+        List<Format> formats = new ArrayList<>();
         for (String formatString : formatStrings) {
             formats.add(getFormat(formatString));
         }

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
@@ -22,7 +22,6 @@ import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.DiagnosticSeverity;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +39,7 @@ public class Rule {
     public List<Format> formats;
     private final List<Format> rulesetFormats;
 
-    public Rule(String name, Map<String, Object> ruleData, HashMap<String, RulesetAliasDefinition> aliases,
+    public Rule(String name, Map<String, Object> ruleData, Map<String, RulesetAliasDefinition> aliases,
                 List<Format> rulesetFormats) {
         this.name = name;
         this.rulesetFormats = new ArrayList<>(rulesetFormats);
@@ -99,7 +98,7 @@ public class Rule {
         }
 
         // resolve given aliases
-        ArrayList<String> resolvedGiven = new ArrayList<>();
+        List<String> resolvedGiven = new ArrayList<>();
         for (String given : this.given) {
             if (given.startsWith(Constants.ALIAS_PREFIX)) {
                 List<Format> aliasFormats;

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Ruleset.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Ruleset.java
@@ -16,11 +16,11 @@
  * under the License.
  */
 package org.wso2.rule.validator.ruleset;
-
 import org.wso2.rule.validator.Constants;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,10 +28,10 @@ import java.util.Map;
  */
 public class Ruleset {
     public final Map<String, Rule> rules;
-    public final HashMap<String, RulesetAliasDefinition> aliases;
+    public final Map<String, RulesetAliasDefinition> aliases;
     private boolean hasComplexAliases;
-    public ArrayList<Format> formats;
-    private ArrayList<Ruleset> extendsRulesets;
+    public List<Format> formats;
+    private List<Ruleset> extendsRulesets;
 
     public Ruleset(Map<String, Object> datamap) {
         this.rules = new HashMap<>();
@@ -47,7 +47,7 @@ public class Ruleset {
 
         // Read formats
         if (datamap.containsKey(Constants.RULESET_FORMATS)) {
-            this.formats = Format.getFormatListFromObject((ArrayList<String>) datamap.get(Constants.RULESET_FORMATS));
+            this.formats = Format.getFormatListFromObject((List<String>) datamap.get(Constants.RULESET_FORMATS));
         }
 
         // Read aliases
@@ -69,22 +69,13 @@ public class Ruleset {
             Rule rule = new Rule(ruleName, (Map<String, Object>) entry.getValue(), this.aliases, this.formats);
             this.rules.put(ruleName, rule);
         }
-
-        // TODO: Read extends
-
-        // TODO: Read recommends
-
-        // TODO: Read overrides
-
-        // TODO: Merge Rules
-
     }
 
     private void resolveAliasesInAliases() {
         while (!allAliasesResolved()) {
             for (RulesetAliasDefinition alias : this.aliases.values()) {
                 if (!alias.isComplexAlias()) {
-                    ArrayList<String> resolvedGiven = new ArrayList<>();
+                    List<String> resolvedGiven = new ArrayList<>();
                     for (String given : alias.given) {
                         if (given.startsWith(Constants.ALIAS_PREFIX)) {
                             resolvedGiven.addAll(RulesetAliasDefinition.resolveAliasGiven(given, this.aliases, null));
@@ -95,7 +86,7 @@ public class Ruleset {
                     alias.given = resolvedGiven;
                 } else {
                     for (RulesetAliasTarget target: alias.targets) {
-                        ArrayList<String> resolvedGiven = new ArrayList<>();
+                        List<String> resolvedGiven = new ArrayList<>();
                         for (String given: target.given) {
                             if (given.startsWith(Constants.ALIAS_PREFIX)) {
                                 resolvedGiven.addAll(RulesetAliasDefinition.resolveAliasGiven(

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/RulesetAliasDefinition.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/RulesetAliasDefinition.java
@@ -20,7 +20,6 @@ package org.wso2.rule.validator.ruleset;
 import org.wso2.rule.validator.Constants;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -35,7 +34,7 @@ import java.util.regex.Pattern;
 public class RulesetAliasDefinition {
     private final String name;
     private String description;
-    public ArrayList<RulesetAliasTarget> targets;
+    public List<RulesetAliasTarget> targets;
     private boolean isComplexAlias;
     public List<String> given;
 
@@ -50,7 +49,7 @@ public class RulesetAliasDefinition {
             Map<String, Object> aliasMap = (Map<String, Object>) aliasObject;
             this.description = (String) aliasMap.get(Constants.DESCRIPTION);
             this.targets = new ArrayList<>();
-            ArrayList<Object> targets = (ArrayList<Object>) aliasMap.get(Constants.RULESET_ALIAS_TARGETS);
+            List<Object> targets = (List<Object>) aliasMap.get(Constants.RULESET_ALIAS_TARGETS);
             for (Object target : targets) {
                 RulesetAliasTarget aliasTarget = new RulesetAliasTarget(target);
                 this.targets.add(aliasTarget);
@@ -62,10 +61,10 @@ public class RulesetAliasDefinition {
         return isComplexAlias;
     }
 
-    public static ArrayList<String> resolveAliasGiven(String given, HashMap<String, RulesetAliasDefinition> aliases,
+    public static List<String> resolveAliasGiven(String given, Map<String, RulesetAliasDefinition> aliases,
                                                       List<Format> formats) {
 
-        ArrayList<String> resolved = new ArrayList<>();
+        List<String> resolved = new ArrayList<>();
 
         String aliasExtractionRegex = Constants.RULESET_ALIAS_EXTRACTION_REGEX;
         Pattern pattern = Pattern.compile(aliasExtractionRegex);

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/RulesetAliasTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/RulesetAliasTarget.java
@@ -19,7 +19,6 @@ package org.wso2.rule.validator.ruleset;
 
 import org.wso2.rule.validator.Constants;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,14 +27,14 @@ import java.util.Map;
  * given path.
  */
 public class RulesetAliasTarget {
-    public ArrayList<Format> formats;
-    public ArrayList<String> given;
+    public List<Format> formats;
+    public List<String> given;
 
     public RulesetAliasTarget (Object targetObject) {
         if (targetObject instanceof Map) {
             Map<String, Object> targetMap = (Map<String, Object>) targetObject;
             this.formats = Format.getFormatListFromObject((List<String>) targetMap.get(Constants.RULESET_FORMATS));
-            this.given = (ArrayList<String>) targetMap.get(Constants.RULESET_GIVEN);
+            this.given = (List<String>) targetMap.get(Constants.RULESET_GIVEN);
         }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
@@ -62,7 +62,7 @@ public class Validator {
         Document document = new Document(documentFile);
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
         List<FunctionResult> functionResults = document.lint(ruleset);
-        ArrayList<DocumentValidationResult> results = new ArrayList<>();
+        List<DocumentValidationResult> results = new ArrayList<>();
         for (FunctionResult functionResult : functionResults) {
             if (functionResult.passed) {
                 continue;

--- a/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
@@ -39,9 +39,7 @@ import java.util.regex.Pattern;
 public abstract class RulesetValidator {
     protected static List<RulesetValidationError> validate(Map<String, Object> ruleset) {
 
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
-
-        // TODO: Validate aliases
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         if (ruleset == null) {
             errors.add(new RulesetValidationError("", "Ruleset is empty."));
@@ -85,13 +83,11 @@ public abstract class RulesetValidator {
         // Validate Formats
         errors.addAll(validateFormats("", ruleset));
 
-
-
         return errors;
     }
 
     private static List<RulesetValidationError> validateRules(Map<String, Object> rules, Object aliases) {
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         for (Map.Entry<String, Object> entry : rules.entrySet()) {
             String key = entry.getKey();
@@ -168,7 +164,7 @@ public abstract class RulesetValidator {
     }
 
     private static List<RulesetValidationError> validateFormats(String ruleName, Map<String, Object> object) {
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         if (object.containsKey(Constants.RULESET_FORMATS) && !(object.get(Constants.RULESET_FORMATS) instanceof List)) {
             errors.add(new RulesetValidationError(ruleName, "'formats' field of a rule should be a list"));
@@ -192,7 +188,7 @@ public abstract class RulesetValidator {
     }
 
     private static List<RulesetValidationError> validateThen (String ruleName, Map<String, Object> rule) {
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         if (!rule.containsKey(Constants.RULESET_THEN)) {
             errors.add(new RulesetValidationError(ruleName, "Rule does not contain a 'then' field."));
@@ -223,7 +219,7 @@ public abstract class RulesetValidator {
     }
 
     private static List<RulesetValidationError> validateThenObject(String ruleName, Map<String, Object> then) {
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         // Field can be undefined. If it is defined, it should be a string
         if (then.containsKey(Constants.RULESET_FIELD) && !(then.get(Constants.RULESET_FIELD) instanceof String)) {
@@ -266,7 +262,7 @@ public abstract class RulesetValidator {
     private static List<RulesetValidationError> validateGiven (String ruleName, Map<String, Object> rule,
                                                                Object aliases) {
 
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         if (!rule.containsKey(Constants.RULESET_GIVEN)) {
             errors.add(new RulesetValidationError(ruleName, "Rule does not contain a 'given' field."));
@@ -290,7 +286,7 @@ public abstract class RulesetValidator {
     }
 
     private static List<RulesetValidationError> validateGiven(String ruleName, String given, Object aliases) {
-        ArrayList<RulesetValidationError> errors = new ArrayList<>();
+        List<RulesetValidationError> errors = new ArrayList<>();
 
         if (given.startsWith(Constants.ALIAS_PREFIX)) {
             if (aliases == null) {


### PR DESCRIPTION
This PR is sent with coding best practices. When creating a variable of a Collection type, the interface type (Map, Set, etc.) should always be used instead of the concrete type (HashMap, HashSet).