### PR TITLE
Remove adding additional backslashes before parsing yaml.

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -24,8 +24,6 @@ import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.functions.FunctionResult;
@@ -33,6 +31,7 @@ import org.wso2.rule.validator.ruleset.Format;
 import org.wso2.rule.validator.ruleset.Rule;
 import org.wso2.rule.validator.ruleset.RuleThen;
 import org.wso2.rule.validator.ruleset.Ruleset;
+import org.wso2.rule.validator.utils.Util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,9 +50,7 @@ public class Document {
     List<Format> formats;
 
     public Document(String documentString) {
-        LoadSettings settings = LoadSettings.builder().build();
-        Load yamlLoader = new Load(settings);
-        Object yamlData = yamlLoader.loadFromString(documentString);
+        Object yamlData = Util.loadYaml(documentString);
 
         if (yamlData == null) {
             return;

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/PatternFunction.java
@@ -21,7 +21,7 @@ import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
 import org.wso2.rule.validator.functions.LintFunction;
-import org.wso2.rule.validator.utils.RulesetUtil;
+import org.wso2.rule.validator.utils.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -204,14 +204,15 @@ public class PatternFunction extends LintFunction {
 
     @Override
     public void processFunctionOptions(Map<String, Object> options) {
+        // Double backslashes are needed here because Java requires double backslashes for regex patterns
         if (options.containsKey(Constants.RULESET_PATTERN_MATCH)) {
             String match = (String) options.get(Constants.RULESET_PATTERN_MATCH);
-            match = RulesetUtil.doubleBackslashesAfterMatch(match);
+            match = Util.doubleBackslashesAfterMatch(match);
             options.put(Constants.RULESET_PATTERN_MATCH, match);
         }
         if (options.containsKey(Constants.RULESET_PATTERN_NOT_MATCH)) {
             String notMatch = (String) options.get(Constants.RULESET_PATTERN_NOT_MATCH);
-            notMatch = RulesetUtil.doubleBackslashesAfterMatch(notMatch);
+            notMatch = Util.doubleBackslashesAfterMatch(notMatch);
             options.put(Constants.RULESET_PATTERN_NOT_MATCH, notMatch);
         }
     }

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/file/type/YamlRuleset.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/file/type/YamlRuleset.java
@@ -17,10 +17,8 @@
  */
 package org.wso2.rule.validator.ruleset.file.type;
 
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.ruleset.Ruleset;
-import org.wso2.rule.validator.utils.RulesetUtil;
+import org.wso2.rule.validator.utils.Util;
 
 import java.util.Map;
 
@@ -29,7 +27,6 @@ import java.util.Map;
  */
 public class YamlRuleset extends Ruleset {
     public YamlRuleset(String rulesetString) {
-        super((Map<String, Object>) (new Load(LoadSettings.builder().build())).loadFromString(
-                RulesetUtil.doubleBackslashesAfterMatch(rulesetString)));
+        super((Map<String, Object>) Util.loadYaml(rulesetString));
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/utils/Util.java
+++ b/component/src/main/java/org/wso2/rule/validator/utils/Util.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.rule.validator.utils;
 
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.Constants;
 
 import java.util.regex.Matcher;
@@ -25,7 +27,7 @@ import java.util.regex.Pattern;
 /**
  * Utility class for ruleset operations.
  */
-public class RulesetUtil {
+public class Util {
     public static String doubleBackslashesAfterMatch(String input) {
         Pattern pattern = Pattern.compile(Constants.RULESET_REGEX_EXTRACTION_REGEX);
 
@@ -53,5 +55,9 @@ public class RulesetUtil {
 
         matcher.appendTail(sb);
         return sb.toString();
+    }
+
+    public static Object loadYaml(String yamlString) {
+        return (new Load(LoadSettings.builder().build())).loadFromString(yamlString);
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
@@ -21,8 +21,6 @@ package org.wso2.rule.validator.validator;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.JsonPath;
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.InvalidContentTypeException;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.Document;
@@ -31,7 +29,7 @@ import org.wso2.rule.validator.ruleset.Ruleset;
 import org.wso2.rule.validator.ruleset.RulesetType;
 import org.wso2.rule.validator.ruleset.file.type.JsonRuleset;
 import org.wso2.rule.validator.ruleset.file.type.YamlRuleset;
-import org.wso2.rule.validator.utils.RulesetUtil;
+import org.wso2.rule.validator.utils.Util;
 import org.wso2.rule.validator.validator.ruleset.RulesetValidationResult;
 
 import java.util.ArrayList;
@@ -104,8 +102,7 @@ public class Validator {
                 JsonPath.parse(ruleset);
                 return RulesetType.JSON;
             } else {
-                Load settings = new Load(LoadSettings.builder().build());
-                settings.loadFromString(RulesetUtil.doubleBackslashesAfterMatch(ruleset));
+                Util.loadYaml(ruleset);
                 return RulesetType.YAML;
             }
         } catch (Exception e) {

--- a/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
@@ -18,9 +18,7 @@
 
 package org.wso2.rule.validator.validator;
 
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.wso2.rule.validator.utils.RulesetUtil;
+import org.wso2.rule.validator.utils.Util;
 import org.wso2.rule.validator.validator.ruleset.RulesetValidator;
 
 import java.util.List;
@@ -31,8 +29,6 @@ import java.util.Map;
  */
 public class YamlRulesetValidator extends RulesetValidator {
     public static List<RulesetValidationError> validateRuleset(String rulesetString) {
-        Load settings = new Load(LoadSettings.builder().build());
-        return RulesetValidator.validate((Map<String, Object>) settings.loadFromString(
-                RulesetUtil.doubleBackslashesAfterMatch(rulesetString)));
+        return RulesetValidator.validate((Map<String, Object>) Util.loadYaml(rulesetString));
     }
 }


### PR DESCRIPTION
Java Regex strings require double backslashes to be in the front. But this causes issues in the Yaml parser hence it's removed with this fix.