### PR TITLE
Send a default message when none is provided for the rule.

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -26,7 +26,7 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>rule.validator</artifactId>
+    <artifactId>org.wso2.rule.validator</artifactId>
 
     <build>
         <plugins>

--- a/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
+++ b/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
@@ -32,7 +32,7 @@ public enum DiagnosticSeverity {
             case ERROR:
                 return "error";
             case WARN:
-                return "warn";
+                return "warning";
             case INFO:
                 return "info";
             case HINT:

--- a/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
+++ b/component/src/main/java/org/wso2/rule/validator/DiagnosticSeverity.java
@@ -32,7 +32,7 @@ public enum DiagnosticSeverity {
             case ERROR:
                 return "error";
             case WARN:
-                return "warning";
+                return "warn";
             case INFO:
                 return "info";
             case HINT:

--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -151,7 +151,8 @@ public class Document {
                 String targetPath = LintTarget.getPathString(parentPath);
                 target.jsonPath = parentPath;
                 FunctionResult result = then.lintFunction.execute(target);
-                results.add(new LintResult(result.passed, targetPath, rule, rule.message == null ? result.message : rule.message));
+                results.add(new LintResult(result.passed, targetPath, rule,
+                        rule.message == null ? result.message : rule.message));
             }
         }
         return results;

--- a/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
@@ -31,11 +31,15 @@ public class LintTarget {
         this.value = value;
     }
 
-    public String getPathString() {
+    public static String getPathString(List<String> jsonPath) {
         StringBuilder resultPath = new StringBuilder();
         for (String path : jsonPath) {
             resultPath.append("[").append(path).append("]");
         }
         return resultPath.toString();
+    }
+
+    public String getTargetName() {
+        return jsonPath.get(jsonPath.size() - 1);
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
@@ -40,6 +40,10 @@ public class LintTarget {
     }
 
     public String getTargetName() {
-        return jsonPath.get(jsonPath.size() - 1);
+        try {
+            return jsonPath.get(jsonPath.size() - 1);
+        } catch (IndexOutOfBoundsException e) {
+            return "";
+        }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
@@ -1,43 +1,14 @@
-/*
- *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
- *
- *  WSO2 LLC. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.wso2.rule.validator.functions;
-
-import org.wso2.rule.validator.ruleset.Rule;
 
 /**
  * Represents the result of a function execution
  */
 public class FunctionResult {
-    public final boolean passed;
-    public final String path;
-    public final Rule rule;
+    public boolean passed;
+    public String message;
 
-    public FunctionResult(boolean passed, String path, Rule rule) {
+    public FunctionResult(boolean passed, String message) {
         this.passed = passed;
-        this.path = path;
-        this.rule = rule;
-    }
-
-    public String toString() {
-        return "Rule: " + this.rule.name + " {\n" +
-                "\tpassed=" + passed +
-                "\n\tpath='" + path + '\'' +
-                "\n\tmessage='" + this.rule.message + '\'' +
-                "\n}";
+        this.message = message;
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/FunctionResult.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.rule.validator.functions;
 
 /**

--- a/component/src/main/java/org/wso2/rule/validator/functions/LintFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/LintFunction.java
@@ -36,7 +36,7 @@ public abstract class LintFunction {
         processFunctionOptions(options);
     }
 
-    public boolean execute(LintTarget target) throws InvalidRulesetException {
+    public FunctionResult execute(LintTarget target) throws InvalidRulesetException {
         List<String> errors = validateFunctionOptions();
         if (!errors.isEmpty()) {
             throw new InvalidRulesetException("Function options are invalid: " + errors);
@@ -44,7 +44,7 @@ public abstract class LintFunction {
         return executeFunction(target);
     }
 
-    protected abstract boolean executeFunction(LintTarget target);
+    protected abstract FunctionResult executeFunction(LintTarget target);
 
     public abstract List<String> validateFunctionOptions();
 

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/AlphabeticalFunction.java
@@ -20,6 +20,7 @@ package org.wso2.rule.validator.functions.core;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -59,15 +60,19 @@ public class AlphabeticalFunction extends LintFunction {
 
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
 
         Object value = target.value;
 
         if (!(value instanceof List) && !(value instanceof Map)) {
-            return true;
+            return new FunctionResult(false, target.getTargetName() + " Value is not a list or a map");
         }
         if (value instanceof Map) {
-            return isAlphabetical((Map) value);
+            if (isAlphabetical((Map) value)) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, target.getTargetName() + " is not alphabetical");
+            }
         }
 
         List<Object> list = (List) value;
@@ -75,26 +80,35 @@ public class AlphabeticalFunction extends LintFunction {
         if (options != null && options.containsKey(Constants.RULESET_ALPHABETICAL_KEYED_BY)) {
             for (Object element : list) {
                 if (!(element instanceof Map)) {
-                    return false;
+                    return new FunctionResult(false, target.getTargetName() + " Value is not a list of maps");
                 }
                 Map<String, Object> map = (Map) element;
                 if (!map.containsKey(options.get(Constants.RULESET_ALPHABETICAL_KEYED_BY))) {
-                    return false;
+                    return new FunctionResult(false, target.getTargetName() + " Map does not contain key " +
+                            options.get(Constants.RULESET_ALPHABETICAL_KEYED_BY));
                 }
                 Object valueToCheck = map.get(options.get(Constants.RULESET_ALPHABETICAL_KEYED_BY));
                 if (!(valueToCheck instanceof String) && !(valueToCheck instanceof Integer) &&
                         !(valueToCheck instanceof Double)) {
-                    return false;
+                    return new FunctionResult(false, target.getTargetName() + " Value is not a list of strings");
                 }
             }
-            return isAlphabetical(list, (String) options.get(Constants.RULESET_ALPHABETICAL_KEYED_BY));
+            if (isAlphabetical(list, (String) options.get(Constants.RULESET_ALPHABETICAL_KEYED_BY))) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, target.getTargetName() + " is not alphabetical");
+            }
         } else {
             for (Object element : list) {
                 if (!(element instanceof String) && !(element instanceof Integer) && !(element instanceof Double)) {
-                    return false;
+                    return new FunctionResult(false, target.getTargetName() + " Value is not a list of strings");
                 }
             }
-            return isAlphabetical(list);
+            if (isAlphabetical(list)) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, target.getTargetName() + " is not alphabetical");
+            }
         }
     }
 

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
@@ -20,6 +20,7 @@ package org.wso2.rule.validator.functions.core;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -90,7 +91,7 @@ public class CasingFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         String targetString = (String) target.value;
         boolean allowLeading = Constants.RULESET_CASING_SEPARATOR_ALLOW_LEADING_DEFAULT;
         String separatorChar = "";
@@ -106,10 +107,14 @@ public class CasingFunction extends LintFunction {
 
         if (targetString.length() == 1 && options.containsKey(Constants.RULESET_CASING_SEPARATOR) && allowLeading &&
                 targetString.equals(separatorChar)) {
-            return true;
+            return new FunctionResult(true, null);
         }
 
-        return targetString.matches(getPattern(options));
+        if (targetString.matches(getPattern(options))) {
+            return new FunctionResult(true, null);
+        } else {
+            return new FunctionResult(false, target.getTargetName() + " does not match the specified casing pattern.");
+        }
     }
 
     private String getPattern(Map<String, Object> options) {

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/DefinedFunction.java
@@ -19,6 +19,7 @@ package org.wso2.rule.validator.functions.core;
 
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -46,7 +47,11 @@ public class DefinedFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
-        return target.value != null;
+    public FunctionResult executeFunction(LintTarget target) {
+        if (target.value != null) {
+            return new FunctionResult(true, target.getTargetName());
+        } else {
+            return new FunctionResult(false, target.getTargetName());
+        }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/EnumerationFunction.java
@@ -20,6 +20,7 @@ package org.wso2.rule.validator.functions.core;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -53,13 +54,13 @@ public class EnumerationFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         String[] values = (String[]) options.get(Constants.RULESET_ENUMERATION_VALUES);
         for (String value : values) {
             if (target.value.equals(value)) {
-                return true;
+                return new FunctionResult(true, null);
             }
         }
-        return false;
+        return new FunctionResult(false, "Value '" + target.value + "' is not in the enumeration.");
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/FalsyFunction.java
@@ -19,6 +19,7 @@ package org.wso2.rule.validator.functions.core;
 
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -46,23 +47,55 @@ public class FalsyFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         if (target.value instanceof String) {
-            return ((String) target.value).isEmpty();
+            if (((String) target.value).isEmpty()) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof List) {
-            return ((List) target.value).isEmpty();
+            if (((List) target.value).isEmpty()) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof Map) {
-            return ((Map) target.value).isEmpty();
+            if (((Map) target.value).isEmpty()) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof Boolean) {
-            return !(Boolean) target.value;
+            if (!(Boolean) target.value) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof Integer) {
-            return (Integer) target.value == 0;
+            if ((Integer) target.value == 0) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof Double) {
-            return (Double) target.value == 0.0;
+            if ((Double) target.value == 0.0) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else if (target.value instanceof Float) {
-            return (Float) target.value == 0.0f;
+            if ((Float) target.value == 0.0f) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         } else {
-            return target.value == null;
+            if (target.value == null) {
+                return new FunctionResult(true, "property \"" + target.getTargetName() + "\" must be falsy");
+            } else {
+                return new FunctionResult(false, null);
+            }
         }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
@@ -20,6 +20,7 @@ package org.wso2.rule.validator.functions.core;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class LengthFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         int length;
 
         if (target.value instanceof String) {
@@ -75,21 +76,34 @@ public class LengthFunction extends LintFunction {
         } else if (target.value instanceof Integer) {
             length = (int) target.value;
         } else {
-            return true;
+            // Following Stoplight Spectral's logic
+            return new FunctionResult(true, null);
         }
 
         if (options.containsKey(Constants.RULESET_LENGTH_MIN) && options.containsKey(Constants.RULESET_LENGTH_MAX)) {
             int min = (int) options.get(Constants.RULESET_LENGTH_MIN);
             int max = (int) options.get(Constants.RULESET_LENGTH_MAX);
-            return length >= min && length <= max;
+            if (length >= min && length <= max) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, "Length should be between " + min + " and " + max);
+            }
         } else  if (options.containsKey(Constants.RULESET_LENGTH_MIN)) {
             int min = (int) options.get(Constants.RULESET_LENGTH_MIN);
-            return length >= min;
+            if (length >= min) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, "Length should be at least " + min);
+            }
         } else if (options.containsKey(Constants.RULESET_LENGTH_MAX)) {
             int max = (int) options.get(Constants.RULESET_LENGTH_MAX);
-            return length <= max;
+            if (length <= max) {
+                return new FunctionResult(true, null);
+            } else {
+                return new FunctionResult(false, "Length should be at most " + max);
+            }
         } else {
-            return false;
+            return new FunctionResult(false, "Length function requires at least a min or a max value.");
         }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/SchemaFunction.java
@@ -25,6 +25,7 @@ import org.json.JSONTokener;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public class SchemaFunction extends LintFunction {
         }
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
 
         String targetString = new Gson().toJson(target.value);
         JSONArray targetArray = null;
@@ -103,7 +104,7 @@ public class SchemaFunction extends LintFunction {
         } else if (targetString.startsWith("{")) {
             targetObject = new JSONObject(targetString);
         } else {
-            return true;
+            return new FunctionResult(false, "Invalid target object.");
         }
 
 
@@ -118,9 +119,9 @@ public class SchemaFunction extends LintFunction {
                 everitSchema.validate(targetArray);
             }
         } catch (org.everit.json.schema.ValidationException e) {
-            return false;
+            return new FunctionResult(false, e.getMessage());
         }
-        return true;
+        return new FunctionResult(true, null);
     }
 
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/TruthyFunction.java
@@ -19,6 +19,7 @@ package org.wso2.rule.validator.functions.core;
 
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -46,19 +47,49 @@ public class TruthyFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         if (target.value instanceof String) {
-            return !((String) target.value).isEmpty();
+            if (((String) target.value).isEmpty()) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         } else if (target.value instanceof List) {
-            return !((List) target.value).isEmpty();
+            if (((List) target.value).isEmpty()) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         } else if (target.value instanceof Map) {
-            return !((Map) target.value).isEmpty();
+            if (((Map) target.value).isEmpty()) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         } else if (target.value instanceof Boolean) {
-            return (Boolean) target.value;
+            if (!(Boolean) target.value) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         } else if (target.value instanceof Integer) {
-            return (Integer) target.value != 0;
+            if ((Integer) target.value == 0) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         } else {
-            return target.value != null;
+            if (target.value == null) {
+                return new FunctionResult(false,
+                        "property\" " + target.getTargetName() + "\" must be truthy");
+            } else {
+                return new FunctionResult(true, null);
+            }
         }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/UndefinedFunction.java
@@ -19,6 +19,7 @@ package org.wso2.rule.validator.functions.core;
 
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -46,7 +47,11 @@ public class UndefinedFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
-        return target.value == null;
+    public FunctionResult executeFunction(LintTarget target) {
+        if (target.value == null) {
+            return new FunctionResult(true, null);
+        } else {
+            return new FunctionResult(false, target.getTargetName() + " is not undefined");
+        }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/XorFunction.java
@@ -20,6 +20,7 @@ package org.wso2.rule.validator.functions.core;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.document.LintTarget;
 import org.wso2.rule.validator.functions.FunctionName;
+import org.wso2.rule.validator.functions.FunctionResult;
 import org.wso2.rule.validator.functions.LintFunction;
 
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class XorFunction extends LintFunction {
         return errors;
     }
 
-    public boolean executeFunction(LintTarget target) {
+    public FunctionResult executeFunction(LintTarget target) {
         List<String> properties = (List<String>) options.get(Constants.RULESET_XOR_PROPERTIES);
         int count = 0;
         for (String property : properties) {
@@ -80,6 +81,10 @@ public class XorFunction extends LintFunction {
             }
         }
 
-        return count == 1;
+        if (count == 1) {
+            return new FunctionResult(true, null);
+        } else {
+            return new FunctionResult(false, "Only one of the properties " + properties + " should be present");
+        }
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
@@ -57,16 +57,18 @@ public class Rule {
             this.description = "";
         }
 
-        if (messageObject instanceof String) {
+        if (messageObject instanceof String && !((String) messageObject).isEmpty()) {
             this.message = (String) messageObject;
+        } else if (descriptionObject instanceof String && !((String) descriptionObject).isEmpty()) {
+            this.message = this.description;
         } else {
-            this.message = "";
+            this.message = null;
         }
 
         if (severityObject instanceof String) {
             this.severity = DiagnosticSeverity.valueOf(StringUtils.toRootUpperCase((String) severityObject));
         } else {
-            this.severity = DiagnosticSeverity.ERROR;
+            this.severity = DiagnosticSeverity.WARN;
         }
 
         if (resolvedObject instanceof Boolean) {

--- a/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
@@ -24,7 +24,7 @@ import com.jayway.jsonpath.JsonPath;
 import org.wso2.rule.validator.InvalidContentTypeException;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.Document;
-import org.wso2.rule.validator.functions.FunctionResult;
+import org.wso2.rule.validator.functions.LintResult;
 import org.wso2.rule.validator.ruleset.Ruleset;
 import org.wso2.rule.validator.ruleset.RulesetType;
 import org.wso2.rule.validator.ruleset.file.type.JsonRuleset;
@@ -59,14 +59,14 @@ public class Validator {
 
         Document document = new Document(documentFile);
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-        List<FunctionResult> functionResults = document.lint(ruleset);
+        List<LintResult> lintResults = document.lint(ruleset);
         List<DocumentValidationResult> results = new ArrayList<>();
-        for (FunctionResult functionResult : functionResults) {
-            if (functionResult.passed) {
+        for (LintResult lintResult : lintResults) {
+            if (lintResult.passed) {
                 continue;
             }
-            results.add(new DocumentValidationResult(functionResult.path, functionResult.rule.message,
-                    functionResult.rule.name, functionResult.rule.severity));
+            results.add(new DocumentValidationResult(lintResult.path, lintResult.rule.message,
+                    lintResult.rule.name, lintResult.rule.severity));
         }
         return gson.toJson(results);
     }

--- a/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
@@ -136,7 +136,7 @@ public abstract class RulesetValidator {
             if (rule.containsKey(Constants.RULESET_SEVERITY) &&
                     !(rule.get(Constants.RULESET_SEVERITY) instanceof String)) {
                 errors.add(new RulesetValidationError(key, "'severity' field of a rule should be a string"));
-            } else {
+            } else if (rule.containsKey(Constants.RULESET_SEVERITY)) {
                 String severity = (String) rule.get(Constants.RULESET_SEVERITY);
                 List<String> severities = Arrays.asList("error", "warn", "info", "hint", "off");
                 if (!severities.contains(severity)) {

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
@@ -20,12 +20,12 @@ package org.wso2.rule.validator.functions.core;
 import org.junit.jupiter.api.Test;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.LintTarget;
+import org.wso2.rule.validator.functions.FunctionResult;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.wso2.rule.validator.functions.FunctionResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.wso2.rule.validator.functions.FunctionResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,8 +46,8 @@ public class FalsyFunctionTest {
         for (Object input : falsyInputs) {
             LintTarget target = new LintTarget(new ArrayList<>(), input);
             try {
-                boolean result = falsy.execute(target);
-                assertTrue(result, "Expected falsy input: " + input + " to be falsy");
+                FunctionResult result = falsy.execute(target);
+                assertTrue(result.passed, "Expected falsy input: " + input + " to be falsy");
             } catch (InvalidRulesetException e) {
                 fail("Exception thrown for falsy input: " + e.getMessage());
             }
@@ -61,8 +62,8 @@ public class FalsyFunctionTest {
         for (Object input : truthyInputs) {
             LintTarget target = new LintTarget(new ArrayList<>(), input);
             try {
-                boolean result = falsy.execute(target);
-                assertFalse(result, "Expected truthy input: " + input + " to be truthy");
+                FunctionResult result = falsy.execute(target);
+                assertFalse(result.passed, "Expected truthy input: " + input + " to be truthy");
             } catch (InvalidRulesetException e) {
                 fail("Exception thrown for truthy input: " + e.getMessage());
             }

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/FalsyFunctionTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class FalsyFunctionTest {
-    private final FalsyFunction falsy = new FalsyFunction(null);
+    public final FalsyFunction falsy = new FalsyFunction(null);
 
     @Test
-    void givenFalsyInputsShouldReturnNoErrorMessage() {
+    public void givenFalsyInputsShouldReturnNoErrorMessage() {
         List<Object> falsyInputs = new ArrayList<>();
         falsyInputs.add(false);
         falsyInputs.add(null);
@@ -55,7 +55,7 @@ public class FalsyFunctionTest {
     }
 
     @Test
-    void givenTruthyInputsShouldReturnErrorMessage() {
+    public void givenTruthyInputsShouldReturnErrorMessage() {
         List<Object> truthyInputs = List.of(true, 1, new ArrayList<>(List.of(1)),
                 new HashMap<>(Map.of("key", "value")));
 
@@ -71,7 +71,7 @@ public class FalsyFunctionTest {
     }
 
     @Test
-    void validationTestForInvalidOptions() {
+    public void validationTestForInvalidOptions() {
         Map<String, Object> invalidOption = Map.of("unsupportedKey", true); // Unsupported key
 
         FalsyFunction function = new FalsyFunction(invalidOption);

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.Test;
 import org.wso2.rule.validator.Constants;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.LintTarget;
+import org.wso2.rule.validator.functions.FunctionResult;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.wso2.rule.validator.functions.FunctionResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.wso2.rule.validator.functions.FunctionResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,8 +66,8 @@ class LengthFunctionTest {
             LengthFunction function = createFunction(options);
 
             try {
-                boolean result = function.execute(target);
-                assertFalse(result, "Expected input to exceed max length of 2");
+                FunctionResult result = function.execute(target);
+                assertFalse(result.passed, "Expected input to exceed max length of 2");
             } catch (InvalidRulesetException e) {
                 // Handle exception, optionally log
                 fail("Exception thrown: " + e.getMessage());
@@ -83,8 +84,8 @@ class LengthFunctionTest {
             LengthFunction function = createFunction(options);
 
             try {
-                boolean result = function.execute(target);
-                assertFalse(result, "Expected input to fall below min length of 4");
+                FunctionResult result = function.execute(target);
+                assertFalse(result.passed, "Expected input to fall below min length of 4");
             } catch (InvalidRulesetException e) {
                 // Handle exception, optionally log
                 fail("Exception thrown: " + e.getMessage());
@@ -102,8 +103,8 @@ class LengthFunctionTest {
             LengthFunction function = createFunction(options);
 
             try {
-                boolean result = function.execute(target);
-                assertTrue(result, "Expected input to be within min and max length of 3");
+                FunctionResult result = function.execute(target);
+                assertTrue(result.passed, "Expected input to be within min and max length of 3");
             } catch (InvalidRulesetException e) {
                 // Handle exception, optionally log
                 fail("Exception thrown: " + e.getMessage());
@@ -123,8 +124,8 @@ class LengthFunctionTest {
             LengthFunction function = createFunction(validOption);
             try {
                 // Validate that no exception is thrown during execution
-                boolean result = function.execute(new LintTarget(new ArrayList<>(), "123"));
-                assertTrue(result, "Expected no exception for valid options.");
+                FunctionResult result = function.execute(new LintTarget(new ArrayList<>(), "123"));
+                assertTrue(result.passed, "Expected no exception for valid options.");
             } catch (InvalidRulesetException e) {
                 // Handle exception, optionally log
                 fail("Exception thrown: " + e.getMessage());

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/LengthFunctionTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class LengthFunctionTest {
+public class LengthFunctionTest {
 
     private List<Object> inputs; // Common input values to test
     private Map<String, Object> options; // Common options map
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         // Initialize common inputs
         inputs = List.of(
                 "123",                  // String
@@ -58,7 +58,7 @@ class LengthFunctionTest {
     }
 
     @Test
-    void testExceedsMaxLength() {
+    public void testExceedsMaxLength() {
         options.put(Constants.RULESET_LENGTH_MAX, 2); // Max length: 2
 
         for (Object input : inputs) {
@@ -76,7 +76,7 @@ class LengthFunctionTest {
     }
 
     @Test
-    void testFallsBelowMinLength() {
+    public void testFallsBelowMinLength() {
         options.put(Constants.RULESET_LENGTH_MIN, 4); // Min length: 4
 
         for (Object input : inputs) {
@@ -94,7 +94,7 @@ class LengthFunctionTest {
     }
 
     @Test
-    void testWithinMinAndMaxLength() {
+    public void testWithinMinAndMaxLength() {
         options.put(Constants.RULESET_LENGTH_MIN, 3); // Min length: 3
         options.put(Constants.RULESET_LENGTH_MAX, 3); // Max length: 3
 
@@ -113,7 +113,7 @@ class LengthFunctionTest {
     }
 
     @Test
-    void testValidOptions() {
+    public void testValidOptions() {
         Map<String, Object>[] validOptions = new Map[]{
                 Map.of(Constants.RULESET_LENGTH_MIN, 2),
                 Map.of(Constants.RULESET_LENGTH_MAX, 4),
@@ -134,7 +134,7 @@ class LengthFunctionTest {
     }
 
     @Test
-    void testInvalidOptions() {
+    public void testInvalidOptions() {
         Map<String, Object>[] invalidOptions = new Map[]{
                 null,                       // Null options
                 Map.of("foo", true),        // Unsupported key

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
@@ -20,13 +20,12 @@ package org.wso2.rule.validator.functions.core;
 import org.junit.jupiter.api.Test;
 import org.wso2.rule.validator.InvalidRulesetException;
 import org.wso2.rule.validator.document.LintTarget;
+import org.wso2.rule.validator.functions.FunctionResult;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.wso2.rule.validator.functions.FunctionResult;
-import org.wso2.rule.validator.functions.LintResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
@@ -32,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class TruthyFunctionTest {
+public class TruthyFunctionTest {
 
     private final TruthyFunction truthy = new TruthyFunction(null);
 
     @Test
-    void givenTruthyInputsShouldReturnNoErrorMessage() {
+    public void givenTruthyInputsShouldReturnNoErrorMessage() {
         List<Object> truthyInputs = List.of(true, 1, new ArrayList<>(List.of(1)),
                 new HashMap<>(Map.of("key", "value")));
 
@@ -53,7 +53,7 @@ class TruthyFunctionTest {
     }
 
     @Test
-    void givenFalsyInputsShouldReturnErrorMessage() {
+    public void givenFalsyInputsShouldReturnErrorMessage() {
         List<Object> falsyInputs = new ArrayList<>();
         falsyInputs.add(false);
         falsyInputs.add(null);
@@ -72,7 +72,7 @@ class TruthyFunctionTest {
     }
 
     @Test
-    void validationTestForInvalidOptions() {
+    public void validationTestForInvalidOptions() {
         Map<String, Object> invalidOption = Map.of("unsupportedKey", true); // Unsupported key
 
         TruthyFunction function = new TruthyFunction(invalidOption);

--- a/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/functions/core/TruthyFunctionTest.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.wso2.rule.validator.functions.FunctionResult;
+import org.wso2.rule.validator.functions.LintResult;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,8 +45,8 @@ class TruthyFunctionTest {
         for (Object input : truthyInputs) {
             LintTarget target = new LintTarget(new ArrayList<>(), input);
             try {
-                boolean result = truthy.execute(target);
-                assertTrue(result, "Expected truthy input: " + input + " to be truthy");
+                FunctionResult result = truthy.execute(target);
+                assertTrue(result.passed, "Expected truthy input: " + input + " to be truthy");
             } catch (InvalidRulesetException e) {
                 fail("Exception thrown for truthy input: " + e.getMessage());
             }
@@ -62,8 +64,8 @@ class TruthyFunctionTest {
         for (Object input : falsyInputs) {
             LintTarget target = new LintTarget(new ArrayList<>(), input);
             try {
-                boolean result = truthy.execute(target);
-                assertFalse(result, "Expected falsy input: " + input + " to be falsy");
+                FunctionResult result = truthy.execute(target);
+                assertFalse(result.passed, "Expected falsy input: " + input + " to be falsy");
             } catch (InvalidRulesetException e) {
                 fail("Exception thrown for falsy input: " + e.getMessage());
             }

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,13 @@
         </repository>
     </repositories>
 
+    <scm>
+        <url>https://github.com/wso2/rule-validator.git</url>
+        <developerConnection>scm:git:https://github.com/wso2/rule-validator.git</developerConnection>
+        <connection>scm:git:https://github.com/wso2/rule-validator.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.spotbugsplugin.version>4.8.2.0</maven.spotbugsplugin.version>


### PR DESCRIPTION
When the `message` field is not defined for a rule, Spectral provides default message according to the function type. The same behaviour is implemented in the Rule Validator with this fix.