### PR TITLE
Use the json path initiator constant instead of hardcoded value and add LintResult file

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/functions/LintResult.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/LintResult.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.rule.validator.functions;
+
+import org.wso2.rule.validator.ruleset.Rule;
+
+/**
+ * Represents the result of a function execution
+ */
+public class LintResult {
+    public final boolean passed;
+    public final String path;
+    public final Rule rule;
+    public final String message;
+
+    public LintResult(boolean passed, String path, Rule rule, String message) {
+        this.passed = passed;
+        this.path = path;
+        this.rule = rule;
+        this.message = message;
+    }
+
+    public String toString() {
+        return "Rule: " + this.rule.name + " {\n" +
+                "\tpassed=" + passed +
+                "\n\tpath='" + path + '\'' +
+                "\n\tmessage='" + this.message + '\'' +
+                "\n}";
+    }
+}

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/CasingFunction.java
@@ -148,7 +148,7 @@ public class CasingFunction extends LintFunction {
         String pattern = basePattern.replace("{__DIGITS__}", allowdigits ? digitPattern : "");
 
         if (!options.containsKey(Constants.RULESET_CASING_SEPARATOR)) {
-            return "^" + pattern + "$";
+            return "^" + pattern + Constants.JSON_PATH_ROOT;
         }
 
         Map<String, Object> separator = (Map<String, Object>) options.get(Constants.RULESET_CASING_SEPARATOR);

--- a/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ruleset/RulesetValidator.java
@@ -310,7 +310,7 @@ public abstract class RulesetValidator {
 
     private static boolean validateJsonPath(String jsonPath) {
         try {
-            if (!jsonPath.startsWith("$")) {
+            if (!jsonPath.startsWith(Constants.JSON_PATH_ROOT)) {
                 return false;
             }
 


### PR DESCRIPTION
Fixes:
- The JSON path initiator constant `$` is now defined in `Constants.java`
- A new `LintResult.java` file is created as a result storage entitiy.