### PR TITLE
Message Placeholders in governance rulesets

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -176,11 +176,11 @@ public class Document {
                 String targetPath = LintTarget.getPathString(parentPath);
                 target.jsonPath = parentPath;
                 FunctionResult result = then.lintFunction.execute(target);
-                MessagePlaceholder placeholder = new MessagePlaceholder(
-                    rule.getDescription(), result.message, target.getTargetName(),
-                    targetPath, target.getValueAsString());
                 String finalMessage;
                 if (rule.message != null) {
+                    MessagePlaceholder placeholder = new MessagePlaceholder(
+                        rule.getDescription(), result.message, target.getTargetName(),
+                        targetPath, target.getValueAsString());
                     finalMessage = placeholder.replacePlaceholders(rule.message);
                 } else {
                     finalMessage = result.message;

--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -170,7 +170,6 @@ public class Document {
         }
         for (RuleThen then : rule.then) {
             List<LintTarget> lintTargets = getLintTargets(node, then);
-
             for (LintTarget target : lintTargets) {
                 List<String> parentPath = splitJsonPath(path);
                 parentPath.addAll(target.jsonPath);
@@ -178,7 +177,7 @@ public class Document {
                 target.jsonPath = parentPath;
                 FunctionResult result = then.lintFunction.execute(target);
                 MessagePlaceholder placeholder = new MessagePlaceholder(
-                    rule.getDescription(), result.message, target.getTargetName(), 
+                    rule.getDescription(), result.message, target.getTargetName(),
                     targetPath, target.getValueAsString());
                 String finalMessage;
                 if (rule.message != null) {

--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -34,6 +34,7 @@ import org.wso2.rule.validator.ruleset.RuleThen;
 import org.wso2.rule.validator.ruleset.Ruleset;
 import org.wso2.rule.validator.ruleset.RulesetAliasDefinition;
 import org.wso2.rule.validator.utils.Util;
+import org.wso2.rule.validator.validator.MessagePlaceholder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -176,8 +177,16 @@ public class Document {
                 String targetPath = LintTarget.getPathString(parentPath);
                 target.jsonPath = parentPath;
                 FunctionResult result = then.lintFunction.execute(target);
-                results.add(new LintResult(result.passed, targetPath, rule,
-                        rule.message == null ? result.message : rule.message));
+                MessagePlaceholder placeholder = new MessagePlaceholder(
+                    rule.getDescription(), result.message, target.getTargetName(), 
+                    targetPath, target.getValueAsString());
+                String finalMessage;
+                if (rule.message != null) {
+                    finalMessage = placeholder.replacePlaceholders(rule.message);
+                } else {
+                    finalMessage = result.message;
+                }
+                results.add(new LintResult(result.passed, targetPath, rule, finalMessage));
             }
         }
         return results;

--- a/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
@@ -18,6 +18,7 @@
 package org.wso2.rule.validator.document;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class represents a lint target in a document.
@@ -46,4 +47,14 @@ public class LintTarget {
             return "";
         }
     }
+    
+    public String getValueAsString() {
+        if (value instanceof Map)
+            return "Object";
+        else if (value instanceof List)
+            return "List";
+        else
+            return String.valueOf(value);
+    }
+
 }

--- a/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/LintTarget.java
@@ -49,12 +49,12 @@ public class LintTarget {
     }
     
     public String getValueAsString() {
-        if (value instanceof Map)
+        if (value instanceof Map) {
             return "Object";
-        else if (value instanceof List)
+        } else if (value instanceof List) {
             return "List";
-        else
+        } else {
             return String.valueOf(value);
+        }
     }
-
 }

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
@@ -52,20 +52,24 @@ public class LengthFunction extends LintFunction {
         }
 
         if (options.containsKey(Constants.RULESET_LENGTH_MIN) &&
-                !(options.get(Constants.RULESET_LENGTH_MIN) instanceof Integer)) {
-            errors.add("Length function min value should be an integer.");
+                !(options.get(Constants.RULESET_LENGTH_MIN) instanceof Integer ||
+                options.get(Constants.RULESET_LENGTH_MIN) instanceof Float || 
+                options.get(Constants.RULESET_LENGTH_MIN) instanceof Double)) {
+            errors.add("Length function min value should be a number.");
         }
 
         if (options.containsKey(Constants.RULESET_LENGTH_MAX) &&
-                !(options.get(Constants.RULESET_LENGTH_MAX) instanceof Integer)) {
-            errors.add("Length function max value should be an integer.");
+                !(options.get(Constants.RULESET_LENGTH_MAX) instanceof Integer ||
+                options.get(Constants.RULESET_LENGTH_MAX) instanceof Float || 
+                options.get(Constants.RULESET_LENGTH_MAX) instanceof Double)) {
+            errors.add("Length function max value should be a number.");
         }
 
         return errors;
     }
 
     public FunctionResult executeFunction(LintTarget target) {
-        int length;
+        Number length;
 
         if (target.value instanceof String) {
             length = ((String) target.value).length();
@@ -73,31 +77,33 @@ public class LengthFunction extends LintFunction {
             length = ((List) target.value).size();
         } else if (target.value instanceof Map) {
             length = ((Map) target.value).size();
-        } else if (target.value instanceof Integer) {
-            length = (int) target.value;
+        } else if (target.value instanceof Integer || target.value instanceof Float ||
+                   target.value instanceof Double) {
+            length = (Number) target.value;
         } else {
             // Following Stoplight Spectral's logic
             return new FunctionResult(true, null);
         }
 
         if (options.containsKey(Constants.RULESET_LENGTH_MIN) && options.containsKey(Constants.RULESET_LENGTH_MAX)) {
-            int min = (int) options.get(Constants.RULESET_LENGTH_MIN);
-            int max = (int) options.get(Constants.RULESET_LENGTH_MAX);
-            if (length >= min && length <= max) {
+            Number min = (Number) options.get(Constants.RULESET_LENGTH_MIN);
+            Number max = (Number) options.get(Constants.RULESET_LENGTH_MAX);
+
+            if (length.doubleValue() >= min.doubleValue() && length.doubleValue() <= max.doubleValue()) {
                 return new FunctionResult(true, null);
             } else {
                 return new FunctionResult(false, "Length should be between " + min + " and " + max);
             }
         } else  if (options.containsKey(Constants.RULESET_LENGTH_MIN)) {
-            int min = (int) options.get(Constants.RULESET_LENGTH_MIN);
-            if (length >= min) {
+            Number min = (Number) options.get(Constants.RULESET_LENGTH_MIN);
+            if (length.doubleValue() >= min.doubleValue()) {
                 return new FunctionResult(true, null);
             } else {
                 return new FunctionResult(false, "Length should be at least " + min);
             }
         } else if (options.containsKey(Constants.RULESET_LENGTH_MAX)) {
-            int max = (int) options.get(Constants.RULESET_LENGTH_MAX);
-            if (length <= max) {
+            Number max = (Number) options.get(Constants.RULESET_LENGTH_MAX);
+            if (length.doubleValue() <= max.doubleValue()) {
                 return new FunctionResult(true, null);
             } else {
                 return new FunctionResult(false, "Length should be at most " + max);
@@ -107,3 +113,4 @@ public class LengthFunction extends LintFunction {
         }
     }
 }
+

--- a/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
+++ b/component/src/main/java/org/wso2/rule/validator/functions/core/LengthFunction.java
@@ -53,16 +53,16 @@ public class LengthFunction extends LintFunction {
 
         if (options.containsKey(Constants.RULESET_LENGTH_MIN) &&
                 !(options.get(Constants.RULESET_LENGTH_MIN) instanceof Integer ||
-                options.get(Constants.RULESET_LENGTH_MIN) instanceof Float || 
+                options.get(Constants.RULESET_LENGTH_MIN) instanceof Float ||
                 options.get(Constants.RULESET_LENGTH_MIN) instanceof Double)) {
-            errors.add("Length function min value should be a number.");
+                    errors.add("Length function min value should be a number.");
         }
 
         if (options.containsKey(Constants.RULESET_LENGTH_MAX) &&
                 !(options.get(Constants.RULESET_LENGTH_MAX) instanceof Integer ||
-                options.get(Constants.RULESET_LENGTH_MAX) instanceof Float || 
+                options.get(Constants.RULESET_LENGTH_MAX) instanceof Float ||
                 options.get(Constants.RULESET_LENGTH_MAX) instanceof Double)) {
-            errors.add("Length function max value should be a number.");
+                    errors.add("Length function max value should be a number.");
         }
 
         return errors;
@@ -113,4 +113,3 @@ public class LengthFunction extends LintFunction {
         }
     }
 }
-

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/Rule.java
@@ -125,4 +125,8 @@ public class Rule {
         return initializationErrorMessage;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/MessagePlaceholder.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/MessagePlaceholder.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.rule.validator.validator;
 
 /**
@@ -22,7 +39,6 @@ public class MessagePlaceholder {
         this.property = property;
         this.path = path;
         this.value = value;
-
     }
 
     public String getDescription() {
@@ -66,7 +82,5 @@ public class MessagePlaceholder {
             result = result.replace(VALUE_PLACEHOLDER, this.getValue());
         }
         return result;
-
     }
-
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/MessagePlaceholder.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/MessagePlaceholder.java
@@ -1,0 +1,72 @@
+package org.wso2.rule.validator.validator;
+
+/**
+ * Placeholder for the rule validator application.
+ */
+public class MessagePlaceholder {
+    public static final String DESCRIPTION_PLACEHOLDER = "{{description}}";
+    public static final String ERROR_PLACEHOLDER = "{{error}}";
+    public static final String PROPERTY_PLACEHOLDER = "{{property}}";
+    public static final String PATH_PLACEHOLDER = "{{path}}";
+    public static final String VALUE_PLACEHOLDER = "{{value}}";
+
+    private String description;
+    private String error;
+    private String property;
+    private String path;
+    private String value;
+
+    public MessagePlaceholder(String description, String error, String property, String path, String value) {
+        this.description = description;
+        this.error = error;
+        this.property = property;
+        this.path = path;
+        this.value = value;
+
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String replacePlaceholders(String template) {
+        if (template == null || template.isEmpty()) {
+            return "";
+        }
+        String result = template;
+        if (this.getDescription() != null) {
+            result = result.replace(DESCRIPTION_PLACEHOLDER, this.getDescription());
+        }
+        if (this.getError() != null) {
+            result = result.replace(ERROR_PLACEHOLDER, this.getError());
+        }
+        if (this.getProperty() != null) {
+            result = result.replace(PROPERTY_PLACEHOLDER, this.getProperty());
+        }
+        if (this.getPath() != null) {
+            result = result.replace(PATH_PLACEHOLDER, this.getPath());
+        }
+        if (this.getValue() != null) {
+            result = result.replace(VALUE_PLACEHOLDER, this.getValue());
+        }
+        return result;
+
+    }
+
+}


### PR DESCRIPTION
## Purpose
Find a way to solve this issue : for the api-no-insecure-transports rule, the message will display {{description}} not the actual description.

