### PR TITLE
Fix checkstyle issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
         <maven.spotbugsplugin.version>4.8.2.0</maven.spotbugsplugin.version>
         <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
-        <root.basedir>${project.basedir}</root.basedir>
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,7 @@
                         <id>validate</id>
                         <phase>compile</phase>
                         <configuration>
-                            <configLocation>
-                                https://raw.githubusercontent.com/wso2/code-quality-tools/v1.2/checkstyle/checkstyle.xml
-                            </configLocation>
+                            <configLocation>${session.topLevelProject.basedir}/checkstyle.xml</configLocation>
                             <suppressionsLocation>suppressions.xml</suppressionsLocation>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
@@ -145,7 +143,7 @@
 
     <properties>
         <project.scm.id>scm-server</project.scm.id>
-        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+        <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
         <maven.spotbugsplugin.version>4.8.2.0</maven.spotbugsplugin.version>
         <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
         <org.snakeyaml.snakeyaml.engine.version>2.9</org.snakeyaml.snakeyaml.engine.version>
@@ -160,6 +158,7 @@
         <maven.spotbugsplugin.version>4.8.2.0</maven.spotbugsplugin.version>
         <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
+        <root.basedir>${project.basedir}</root.basedir>
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
     </properties>
 </project>


### PR DESCRIPTION
This pull request updates the project's code quality tooling configuration in `pom.xml`, focusing on improving maintainability and ensuring the use of local resources.

Code quality configuration updates:

* Changed the Checkstyle configuration to use a local `checkstyle.xml` file instead of fetching it from a remote URL, making builds more reliable and easier to customize.
* Upgraded the Maven Checkstyle Plugin version from `3.0.0` to `3.3.0` to benefit from the latest features and bug fixes.