### PR TITLE
Improve validation in json/yaml rulesets

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/validator/JsonRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/JsonRulesetValidator.java
@@ -33,7 +33,7 @@ public class JsonRulesetValidator extends RulesetValidator {
             throws InvalidContentTypeException {
         Object jsonContent = JsonPath.parse(rulesetString).json();
         if (!(jsonContent instanceof Map)) {
-            throw new InvalidContentTypeException("Invalid JSON content.");
+            throw new InvalidContentTypeException("Invalid JSON ruleset content.");
         }
         return RulesetValidator.validate((Map<String, Object>) jsonContent);
     }

--- a/component/src/main/java/org/wso2/rule/validator/validator/JsonRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/JsonRulesetValidator.java
@@ -19,6 +19,7 @@
 package org.wso2.rule.validator.validator;
 
 import com.jayway.jsonpath.JsonPath;
+import org.wso2.rule.validator.InvalidContentTypeException;
 import org.wso2.rule.validator.validator.ruleset.RulesetValidator;
 
 import java.util.List;
@@ -28,7 +29,12 @@ import java.util.Map;
  * Ruleset validation for JSON files
  */
 public class JsonRulesetValidator extends RulesetValidator {
-    public static List<RulesetValidationError> validateRuleset(String rulesetString) {
-        return RulesetValidator.validate((Map<String, Object>) JsonPath.parse(rulesetString).json());
+    public static List<RulesetValidationError> validateRuleset(String rulesetString)
+            throws InvalidContentTypeException {
+        Object jsonContent = JsonPath.parse(rulesetString).json();
+        if (!(jsonContent instanceof Map)) {
+            throw new InvalidContentTypeException("Invalid JSON content.");
+        }
+        return RulesetValidator.validate((Map<String, Object>) jsonContent);
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
@@ -18,6 +18,7 @@
 
 package org.wso2.rule.validator.validator;
 
+import org.wso2.rule.validator.InvalidContentTypeException;
 import org.wso2.rule.validator.utils.Util;
 import org.wso2.rule.validator.validator.ruleset.RulesetValidator;
 
@@ -28,7 +29,12 @@ import java.util.Map;
  * Ruleset validation for YAML files
  */
 public class YamlRulesetValidator extends RulesetValidator {
-    public static List<RulesetValidationError> validateRuleset(String rulesetString) {
-        return RulesetValidator.validate((Map<String, Object>) Util.loadYaml(rulesetString));
+    public static List<RulesetValidationError> validateRuleset(String rulesetString)
+            throws InvalidContentTypeException {
+        Object yamlContent = Util.loadYaml(rulesetString);
+        if (!(yamlContent instanceof Map)) {
+            throw new InvalidContentTypeException("Invalid YAML content.");
+        }
+        return RulesetValidator.validate((Map<String, Object>) yamlContent);
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
@@ -33,7 +33,7 @@ public class YamlRulesetValidator extends RulesetValidator {
             throws InvalidContentTypeException {
         Object yamlContent = Util.loadYaml(rulesetString);
         if (!(yamlContent instanceof Map)) {
-            throw new InvalidContentTypeException("Invalid YAML content.");
+            throw new InvalidContentTypeException("Invalid YAML ruleset content.");
         }
         return RulesetValidator.validate((Map<String, Object>) yamlContent);
     }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-manager/issues/3712

## Goals
Preventing the class cast exception that occurs dues to invalid json/yaml ruleset

## Approach
Added type checking

## Samples
N/A