### PR TITLE
Add ValidationOptions for configurable document and ruleset validation

### DIFF
--- a/component/src/main/java/org/wso2/rule/validator/document/Document.java
+++ b/component/src/main/java/org/wso2/rule/validator/document/Document.java
@@ -35,6 +35,7 @@ import org.wso2.rule.validator.ruleset.Ruleset;
 import org.wso2.rule.validator.ruleset.RulesetAliasDefinition;
 import org.wso2.rule.validator.utils.Util;
 import org.wso2.rule.validator.validator.MessagePlaceholder;
+import org.wso2.rule.validator.validator.ValidationOptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,8 +53,25 @@ public class Document {
     private Object document = null;
     List<Format> formats;
 
+    /**
+     * Creates a document using default validation options.
+     *
+     * @param documentString document content
+     * @deprecated Use {@link #Document(String, ValidationOptions)} to pass validation options.
+     */
+    @Deprecated
     public Document(String documentString) {
-        Object yamlData = Util.loadYaml(documentString);
+        this(documentString, ValidationOptions.defaults());
+    }
+
+    /**
+     * Creates a document using provided validation options.
+     *
+     * @param documentString    document content
+     * @param validationOptions validation options
+     */
+    public Document(String documentString, ValidationOptions validationOptions) {
+        Object yamlData = Util.loadYaml(documentString, validationOptions);
 
         if (yamlData == null) {
             return;

--- a/component/src/main/java/org/wso2/rule/validator/ruleset/file/type/YamlRuleset.java
+++ b/component/src/main/java/org/wso2/rule/validator/ruleset/file/type/YamlRuleset.java
@@ -19,6 +19,7 @@ package org.wso2.rule.validator.ruleset.file.type;
 
 import org.wso2.rule.validator.ruleset.Ruleset;
 import org.wso2.rule.validator.utils.Util;
+import org.wso2.rule.validator.validator.ValidationOptions;
 
 import java.util.Map;
 
@@ -26,7 +27,24 @@ import java.util.Map;
  * This class is used to load a yaml ruleset file
  */
 public class YamlRuleset extends Ruleset {
+    /**
+     * Creates a YAML ruleset using default validation options.
+     *
+     * @param rulesetString ruleset content
+     * @deprecated Use {@link #YamlRuleset(String, ValidationOptions)} to pass validation options.
+     */
+    @Deprecated
     public YamlRuleset(String rulesetString) {
-        super((Map<String, Object>) Util.loadYaml(rulesetString));
+        this(rulesetString, ValidationOptions.defaults());
+    }
+
+    /**
+     * Creates a YAML ruleset using provided validation options.
+     *
+     * @param rulesetString     ruleset content
+     * @param validationOptions validation options
+     */
+    public YamlRuleset(String rulesetString, ValidationOptions validationOptions) {
+        super((Map<String, Object>) Util.loadYaml(rulesetString, validationOptions));
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/utils/Util.java
+++ b/component/src/main/java/org/wso2/rule/validator/utils/Util.java
@@ -19,7 +19,9 @@ package org.wso2.rule.validator.utils;
 
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.LoadSettingsBuilder;
 import org.wso2.rule.validator.Constants;
+import org.wso2.rule.validator.validator.ValidationOptions;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -57,7 +59,31 @@ public class Util {
         return sb.toString();
     }
 
+    /**
+     * Loads YAML content using default validation options.
+     *
+     * @param yamlString YAML content as string
+     * @return parsed YAML object
+     * @deprecated Use {@link #loadYaml(String, ValidationOptions)} to pass parser options explicitly.
+     */
+    @Deprecated
     public static Object loadYaml(String yamlString) {
-        return (new Load(LoadSettings.builder().build())).loadFromString(yamlString);
+        return loadYaml(yamlString, ValidationOptions.defaults());
+    }
+
+    /**
+     * Loads YAML content with configurable validation options.
+     *
+     * @param yamlString        YAML content as string
+     * @param validationOptions parser/validation options
+     * @return parsed YAML object
+     */
+    public static Object loadYaml(String yamlString, ValidationOptions validationOptions) {
+        LoadSettingsBuilder loadSettingsBuilder = LoadSettings.builder();
+        Integer yamlCodePointLimit = validationOptions != null ? validationOptions.getYamlCodePointLimit() : null;
+        if (yamlCodePointLimit != null && yamlCodePointLimit > 0) {
+            loadSettingsBuilder.setCodePointLimit(yamlCodePointLimit);
+        }
+        return (new Load(loadSettingsBuilder.build())).loadFromString(yamlString);
     }
 }

--- a/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
@@ -23,7 +23,7 @@ package org.wso2.rule.validator.validator;
  */
 public class ValidationOptions {
 
-    private Integer yamlCodePointLimit;
+    private Integer yamlCodePointLimit = null;
 
     public ValidationOptions() {
     }

--- a/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.rule.validator.validator;
+
+/**
+ * Options used while validating documents and rulesets.
+ */
+public class ValidationOptions {
+
+    private Integer yamlCodePointLimit;
+
+    public ValidationOptions() {
+    }
+
+    public static ValidationOptions defaults() {
+        return new ValidationOptions();
+    }
+
+    public Integer getYamlCodePointLimit() {
+        return yamlCodePointLimit;
+    }
+
+    public void setYamlCodePointLimit(Integer yamlCodePointLimit) {
+        this.yamlCodePointLimit = yamlCodePointLimit;
+    }
+}

--- a/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/ValidationOptions.java
@@ -23,9 +23,10 @@ package org.wso2.rule.validator.validator;
  */
 public class ValidationOptions {
 
-    private Integer yamlCodePointLimit = null;
+    private Integer yamlCodePointLimit;
 
     public ValidationOptions() {
+        this.yamlCodePointLimit = null;
     }
 
     public static ValidationOptions defaults() {

--- a/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/Validator.java
@@ -39,20 +39,46 @@ import java.util.List;
  * Validator class to validate documents and rulesets.
  */
 public class Validator {
+    /**
+     * Validates a document with a ruleset using default validation options.
+     *
+     * @param documentFile document content
+     * @param rulesetFile  ruleset content
+     * @return validation result as JSON string
+     * @throws InvalidRulesetException     if ruleset is invalid
+     * @throws InvalidContentTypeException if content is not valid JSON or YAML
+     * @deprecated Use {@link #validateDocument(String, String, ValidationOptions)} to pass validation options.
+     */
+    @Deprecated
     public static String validateDocument(String documentFile, String rulesetFile)
             throws InvalidRulesetException, InvalidContentTypeException {
+        return validateDocument(documentFile, rulesetFile, ValidationOptions.defaults());
+    }
 
-        List<RulesetValidationError> errors = getRulesetValidationErrors(rulesetFile);
+    /**
+     * Validates a document with a ruleset using provided validation options.
+     *
+     * @param documentFile      document content
+     * @param rulesetFile       ruleset content
+     * @param validationOptions validation options
+     * @return validation result as JSON string
+     * @throws InvalidRulesetException     if ruleset is invalid
+     * @throws InvalidContentTypeException if content is not valid JSON or YAML
+     */
+    public static String validateDocument(String documentFile, String rulesetFile, ValidationOptions validationOptions)
+            throws InvalidRulesetException, InvalidContentTypeException {
+
+        List<RulesetValidationError> errors = getRulesetValidationErrors(rulesetFile, validationOptions);
         if (!errors.isEmpty()) {
             Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
             throw new InvalidRulesetException(gson.toJson(errors));
         }
 
-        RulesetType type = findRulesetType(rulesetFile);
+        RulesetType type = findRulesetType(rulesetFile, validationOptions);
         Ruleset ruleset;
 
         if (type == RulesetType.YAML) {
-            ruleset = new YamlRuleset(rulesetFile);
+            ruleset = new YamlRuleset(rulesetFile, validationOptions);
         } else {
             ruleset = new JsonRuleset(rulesetFile);
         }
@@ -61,7 +87,7 @@ public class Validator {
             throw new InvalidRulesetException(ruleset.getInitializationErrorMessage());
         }
 
-        Document document = new Document(documentFile);
+        Document document = new Document(documentFile, validationOptions);
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
         List<DocumentValidationResult> results = new ArrayList<>();
         if (!document.isNull()) {
@@ -79,20 +105,42 @@ public class Validator {
         return gson.toJson(results);
     }
 
-    private static List<RulesetValidationError> getRulesetValidationErrors(String rulesetString)
-            throws InvalidContentTypeException {
-        RulesetType type = findRulesetType(rulesetString);
+    private static List<RulesetValidationError> getRulesetValidationErrors(String rulesetString,
+            ValidationOptions validationOptions) throws InvalidContentTypeException {
+        RulesetType type = findRulesetType(rulesetString, validationOptions);
         List<RulesetValidationError> errors;
         if (type == RulesetType.YAML) {
-            errors = YamlRulesetValidator.validateRuleset(rulesetString);
+            errors = YamlRulesetValidator.validateRuleset(rulesetString, validationOptions);
         } else {
             errors = JsonRulesetValidator.validateRuleset(rulesetString);
         }
         return errors;
     }
 
+    /**
+     * Validates a ruleset using default validation options.
+     *
+     * @param rulesetString ruleset content
+     * @return validation result as JSON string
+     * @throws InvalidContentTypeException if content is not valid JSON or YAML
+     * @deprecated Use {@link #validateRuleset(String, ValidationOptions)} to pass validation options.
+     */
+    @Deprecated
     public static String validateRuleset(String rulesetString) throws InvalidContentTypeException {
-        List<RulesetValidationError> errors = getRulesetValidationErrors(rulesetString);
+        return validateRuleset(rulesetString, ValidationOptions.defaults());
+    }
+
+    /**
+     * Validates a ruleset using provided validation options.
+     *
+     * @param rulesetString     ruleset content
+     * @param validationOptions validation options
+     * @return validation result as JSON string
+     * @throws InvalidContentTypeException if content is not valid JSON or YAML
+     */
+    public static String validateRuleset(String rulesetString, ValidationOptions validationOptions)
+            throws InvalidContentTypeException {
+        List<RulesetValidationError> errors = getRulesetValidationErrors(rulesetString, validationOptions);
         Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
         // Create a string with all the error strings
         StringBuilder errorString = new StringBuilder();
@@ -103,14 +151,15 @@ public class Validator {
         return gson.toJson(result);
     }
 
-    private static RulesetType findRulesetType(String ruleset) throws InvalidContentTypeException {
+    private static RulesetType findRulesetType(String ruleset, ValidationOptions validationOptions)
+            throws InvalidContentTypeException {
         try {
             String trimmedRuleset = ruleset.trim();
             if (trimmedRuleset.startsWith("{") || trimmedRuleset.startsWith("[")) {
                 JsonPath.parse(ruleset);
                 return RulesetType.JSON;
             } else {
-                Util.loadYaml(ruleset);
+                Util.loadYaml(ruleset, validationOptions);
                 return RulesetType.YAML;
             }
         } catch (Exception e) {

--- a/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
+++ b/component/src/main/java/org/wso2/rule/validator/validator/YamlRulesetValidator.java
@@ -29,9 +29,31 @@ import java.util.Map;
  * Ruleset validation for YAML files
  */
 public class YamlRulesetValidator extends RulesetValidator {
+    /**
+     * Validates YAML ruleset content using default validation options.
+     *
+     * @param rulesetString ruleset content
+     * @return list of validation errors
+     * @throws InvalidContentTypeException if ruleset content is invalid YAML
+     * @deprecated Use {@link #validateRuleset(String, ValidationOptions)} to pass validation options.
+     */
+    @Deprecated
     public static List<RulesetValidationError> validateRuleset(String rulesetString)
             throws InvalidContentTypeException {
-        Object yamlContent = Util.loadYaml(rulesetString);
+        return validateRuleset(rulesetString, ValidationOptions.defaults());
+    }
+
+    /**
+     * Validates YAML ruleset content using provided validation options.
+     *
+     * @param rulesetString     ruleset content
+     * @param validationOptions validation options
+     * @return list of validation errors
+     * @throws InvalidContentTypeException if ruleset content is invalid YAML
+     */
+    public static List<RulesetValidationError> validateRuleset(String rulesetString,
+            ValidationOptions validationOptions) throws InvalidContentTypeException {
+        Object yamlContent = Util.loadYaml(rulesetString, validationOptions);
         if (!(yamlContent instanceof Map)) {
             throw new InvalidContentTypeException("Invalid YAML ruleset content.");
         }

--- a/component/src/test/java/org/wso2/rule/validator/ruleset/RulesetTest.java
+++ b/component/src/test/java/org/wso2/rule/validator/ruleset/RulesetTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.wso2.rule.validator.InvalidContentTypeException;
+import org.wso2.rule.validator.validator.ValidationOptions;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,7 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wso2.rule.validator.validator.Validator.validateRuleset;
 
@@ -174,9 +177,10 @@ public class RulesetTest {
         try {
             String jsonRulesetContent = Files.readString(jsonRulesetPath);
             String yamlRulesetContent = Files.readString(yamlRulesetPath);
+            ValidationOptions validationOptions = ValidationOptions.defaults();
 
-            String validationResultJson = validateRuleset(jsonRulesetContent);
-            String validationResultYaml = validateRuleset(yamlRulesetContent);
+            String validationResultJson = validateRuleset(jsonRulesetContent, validationOptions);
+            String validationResultYaml = validateRuleset(yamlRulesetContent, validationOptions);
 
             assertTrue(validationResultJson.contains("Circular alias dependency detected."));
             assertTrue(validationResultYaml.contains("Circular alias dependency detected."));
@@ -195,13 +199,49 @@ public class RulesetTest {
         try {
             String jsonRulesetContent = Files.readString(jsonRulesetPath);
             String yamlRulesetContent = Files.readString(yamlRulesetPath);
+            ValidationOptions validationOptions = ValidationOptions.defaults();
 
-            String validationResultJson = validateRuleset(jsonRulesetContent);
-            String validationResultYaml = validateRuleset(yamlRulesetContent);
+            String validationResultJson = validateRuleset(jsonRulesetContent, validationOptions);
+            String validationResultYaml = validateRuleset(yamlRulesetContent, validationOptions);
 
             assertTrue(validationResultJson.contains("Alias #Name not found"));
             assertTrue(validationResultYaml.contains("Alias #Name not found"));
         } catch (IOException | InvalidContentTypeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Tests that null yaml code point limit follows default parsing behavior.
+     */
+    @Test
+    public void validateRulesetWithNullCodePointLimit() {
+        Path yamlRulesetPath = Paths.get("src/test/resources/rulesets/valid-yaml.ruleset");
+        try {
+            String yamlRulesetContent = Files.readString(yamlRulesetPath);
+            ValidationOptions validationOptions = new ValidationOptions();
+            validationOptions.setYamlCodePointLimit(null);
+
+            assertDoesNotThrow(() -> validateRuleset(yamlRulesetContent, validationOptions));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Tests that yaml code point limit is enforced when a positive value is configured.
+     */
+    @Test
+    public void validateRulesetWithConfiguredCodePointLimit() {
+        Path yamlRulesetPath = Paths.get("src/test/resources/rulesets/valid-yaml.ruleset");
+        try {
+            String yamlRulesetContent = Files.readString(yamlRulesetPath);
+            ValidationOptions validationOptions = new ValidationOptions();
+            validationOptions.setYamlCodePointLimit(10);
+
+            assertThrows(InvalidContentTypeException.class,
+                    () -> validateRuleset(yamlRulesetContent, validationOptions));
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/component/src/test/java/org/wso2/rule/validator/validator/Scenario.java
+++ b/component/src/test/java/org/wso2/rule/validator/validator/Scenario.java
@@ -69,7 +69,8 @@ public class Scenario {
         String ruleset = processRuleset(rulesetKey);
 
         try {
-            String result = Validator.validateDocument(document, ruleset);
+            ValidationOptions validationOptions = ValidationOptions.defaults();
+            String result = Validator.validateDocument(document, ruleset, validationOptions);
             return matchResults(result);
         } catch (InvalidRulesetException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
### Purpose

This pull request introduces a new `ValidationOptions` class to allow configurable validation and parsing options throughout the rule validator, with a focus on YAML code point limits. The changes ensure that all relevant APIs, document/ruleset loaders, and validators can now accept these options, while maintaining backward compatibility via deprecated constructors and methods. Additionally, new tests were added to verify the correct application of these options.

**Validation Options Integration:**
- Added a new `ValidationOptions` class to encapsulate parser and validation options, such as YAML code point limits, with a default factory method and getter/setter.
- Updated `Util.loadYaml`, `Document`, `YamlRuleset`, and all validator methods to accept `ValidationOptions`, falling back to defaults for deprecated methods/constructors. [[1]](diffhunk://#diff-c1c05b9cf288ad8ea60b8eb09d6107cd6bf67fa9dc75363e0da0ceef64356ffaR38) [[2]](diffhunk://#diff-c1c05b9cf288ad8ea60b8eb09d6107cd6bf67fa9dc75363e0da0ceef64356ffaR56-R74) [[3]](diffhunk://#diff-61fdb5177d8f8965d87917a67b626fffb1ac2347d5e433c3c3f507f4d8b0ac70R22-R48) [[4]](diffhunk://#diff-61fdb5177d8f8965d87917a67b626fffb1ac2347d5e433c3c3f507f4d8b0ac70R22-R48) [[5]](diffhunk://#diff-2e480daad6b2a5ed84e7d881fa3c72a6eae9446fe9aed1571c149ca62b864d0dR22-R24) [[6]](diffhunk://#diff-2e480daad6b2a5ed84e7d881fa3c72a6eae9446fe9aed1571c149ca62b864d0dR62-R87) [[7]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2R42-R81) [[8]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2L64-R90) [[9]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2L82-R143) [[10]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2L106-R162) [[11]](diffhunk://#diff-1d0468f7f150ff38d47f496abd19ee8b64eaef0b24b3d9f3b523a053f4c82a68R32-R56)

**Backward Compatibility:**
- Marked previous constructors and methods as `@Deprecated` and redirected them to the new overloads with `ValidationOptions`. [[1]](diffhunk://#diff-c1c05b9cf288ad8ea60b8eb09d6107cd6bf67fa9dc75363e0da0ceef64356ffaR56-R74) [[2]](diffhunk://#diff-61fdb5177d8f8965d87917a67b626fffb1ac2347d5e433c3c3f507f4d8b0ac70R22-R48) [[3]](diffhunk://#diff-2e480daad6b2a5ed84e7d881fa3c72a6eae9446fe9aed1571c149ca62b864d0dR62-R87) [[4]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2R42-R81) [[5]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2L82-R143) [[6]](diffhunk://#diff-1d0468f7f150ff38d47f496abd19ee8b64eaef0b24b3d9f3b523a053f4c82a68R32-R56)

**Tests and Usage:**
- Updated tests to use the new `ValidationOptions` API, and added new tests for YAML code point limit enforcement and default/null handling. [[1]](diffhunk://#diff-36dec4c089edb4d0996162628ee53065a81214741581c627446aa61c2767ed51R26) [[2]](diffhunk://#diff-36dec4c089edb4d0996162628ee53065a81214741581c627446aa61c2767ed51R36-R38) [[3]](diffhunk://#diff-36dec4c089edb4d0996162628ee53065a81214741581c627446aa61c2767ed51R180-R183) [[4]](diffhunk://#diff-36dec4c089edb4d0996162628ee53065a81214741581c627446aa61c2767ed51R202-R247) [[5]](diffhunk://#diff-2685d705c0cea791a166b09997673087fbb9a95b924b3cb76de26d3073c65c80L72-R73)

**YAML Parsing Improvements:**
- Enhanced `Util.loadYaml` to set the YAML code point limit from `ValidationOptions`, enforcing limits only when a positive value is configured.

**Documentation:**
- Added Javadoc comments to all new APIs and deprecated methods to clarify usage and migration paths. [[1]](diffhunk://#diff-c1c05b9cf288ad8ea60b8eb09d6107cd6bf67fa9dc75363e0da0ceef64356ffaR56-R74) [[2]](diffhunk://#diff-61fdb5177d8f8965d87917a67b626fffb1ac2347d5e433c3c3f507f4d8b0ac70R22-R48) [[3]](diffhunk://#diff-2e480daad6b2a5ed84e7d881fa3c72a6eae9446fe9aed1571c149ca62b864d0dR62-R87) [[4]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2R42-R81) [[5]](diffhunk://#diff-39d07667147e1a3b6ced74ef29f22e83561ab4914f96d0f616e021e5cfc245b2L82-R143) [[6]](diffhunk://#diff-1d0468f7f150ff38d47f496abd19ee8b64eaef0b24b3d9f3b523a053f4c82a68R32-R56)

**Related Issu**
- https://github.com/wso2/api-manager/issues/4565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable validation options to control YAML parsing (including a code-point limit) and new validation overloads that accept these options. Legacy no-options variants are deprecated and now delegate to defaults.

* **Tests**
  * Added tests for null and configured YAML code-point limits and updated existing validation tests to use the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->